### PR TITLE
Fixed empty search queries

### DIFF
--- a/root/scripts/searchpage.js
+++ b/root/scripts/searchpage.js
@@ -30,7 +30,7 @@ async function init() {
   const searchQuery = searchParams.get('searchQuery');
   const filterTags = searchParams.get('tags')?.split(',') || [];
 
-  if (searchQuery === null || searchQuery === undefined) {
+  if (searchQuery === null || searchQuery === undefined || searchQuery.length === 0) {
     const searchResultsContainer = document.getElementById('search-results-container');
     searchResultsContainer.style.display = 'flex';
     searchResultsContainer.style.maxWidth = '100%';


### PR DESCRIPTION
Previously: searching without inputting anything generated infinite recipes
<img width="1259" alt="Screen Shot 2022-05-11 at 4 54 24 PM" src="https://user-images.githubusercontent.com/57045574/167965900-69316591-7a41-48ec-8c33-b92733f10767.png">


Now: Displays a message encouraging user to search something
<img width="1173" alt="Screen Shot 2022-05-11 at 4 53 54 PM" src="https://user-images.githubusercontent.com/57045574/167965874-fbc78334-dc96-49d7-af14-93d4dd2dea94.png">