### PR TITLE
TEAMROCKET#29: getAllRecipes() From Firebase

### DIFF
--- a/root/scripts/utils.js
+++ b/root/scripts/utils.js
@@ -1,11 +1,10 @@
 /** @module utils */
 /* eslint-disable no-mixed-operators */
-const COMMUNITY_HALF_RECIPE_URL = 'https://raw.githubusercontent.com/cse110-fa21-group34/rocketrecipes/main/root/scraper/recipes.json_2.json';
-const COMMUNITY_THIRD_RECIPE_URL = 'https://raw.githubusercontent.com/cse110-fa21-group34/rocketrecipes/main/root/scraper/recipes.json_3.json';
-const COMMUNITY_QUARTER_RECIPE_URL = 'https://raw.githubusercontent.com/cse110-fa21-group34/rocketrecipes/main/root/scraper/recipes.json_4.json';
-const COMMUNITY_TENTH_RECIPE_URL = 'https://raw.githubusercontent.com/cse110-fa21-group34/rocketrecipes/main/root/scraper/recipes.json_10.json';
 const LOCAL_STORAGE_ALL_RECIPES_KEY = 'allRecipes';
 const LOCAL_STORAGE_FAVORITED_RECIPES_KEY = 'favoritedRecipes';
+
+const FIREBASE_BASE_URL = 'https://rocketrecipes-6c192-default-rtdb.firebaseio.com';
+const AUTH_KEY = 'DkCjtMgbGLJNFLVxTMzfZdrXGGiDbZPwKhn8yKMo';
 
 /**
  * @async
@@ -13,44 +12,11 @@ const LOCAL_STORAGE_FAVORITED_RECIPES_KEY = 'favoritedRecipes';
  * @returns {Array} An array of recipe objects, following the given schema
  */
 export async function getAllRecipes() {
-  if (localStorage.getItem(LOCAL_STORAGE_ALL_RECIPES_KEY) !== null) {
-    const localStorageRecipes = JSON.parse(localStorage.getItem(LOCAL_STORAGE_ALL_RECIPES_KEY));
-    return localStorageRecipes;
-  }
-  let fetchedRecipes = await fetch(COMMUNITY_HALF_RECIPE_URL)
-    .then((response) => response.json())
-    .then((data) => data);
-
-  try {
-    localStorage.setItem(LOCAL_STORAGE_ALL_RECIPES_KEY, JSON.stringify(fetchedRecipes));
-  } catch (fe) {
-    try {
-      fetchedRecipes = await fetch(COMMUNITY_THIRD_RECIPE_URL)
-        .then((response) => response.json())
-        .then((data) => data);
-
-      localStorage.setItem(LOCAL_STORAGE_ALL_RECIPES_KEY, JSON.stringify(fetchedRecipes));
-    } catch (e) {
-      try {
-        fetchedRecipes = await fetch(COMMUNITY_QUARTER_RECIPE_URL)
-          .then((response) => response.json())
-          .then((data) => data);
-
-        localStorage.setItem(LOCAL_STORAGE_ALL_RECIPES_KEY, JSON.stringify(fetchedRecipes));
-      } catch (se) {
-        try {
-          fetchedRecipes = await fetch(COMMUNITY_TENTH_RECIPE_URL)
-            .then((response) => response.json())
-            .then((data) => data);
-
-          localStorage.setItem(LOCAL_STORAGE_ALL_RECIPES_KEY, JSON.stringify(fetchedRecipes));
-        } catch (te) {
-          return null;
-        }
-      }
-    }
-  }
-  return fetchedRecipes;
+  const url = `${FIREBASE_BASE_URL}/recipes.json?auth=${AUTH_KEY}`;
+  let data = await fetch(url);
+  let recipes = await data.json();
+  console.log(recipes);
+  return recipes;
 }
 
 /**

--- a/root/scripts/utils.js
+++ b/root/scripts/utils.js
@@ -15,7 +15,7 @@ export async function getAllRecipes() {
   const url = `${FIREBASE_BASE_URL}/recipes.json?auth=${AUTH_KEY}`;
   let data = await fetch(url);
   let recipes = await data.json();
-  console.log(recipes);
+  recipes = Object.values(recipes);
   return recipes;
 }
 

--- a/root/scripts/utils.js
+++ b/root/scripts/utils.js
@@ -13,7 +13,7 @@ const AUTH_KEY = 'DkCjtMgbGLJNFLVxTMzfZdrXGGiDbZPwKhn8yKMo';
  */
 export async function getAllRecipes() {
   const url = `${FIREBASE_BASE_URL}/recipes.json?auth=${AUTH_KEY}`;
-  let data = await fetch(url);
+  const data = await fetch(url);
   let recipes = await data.json();
   recipes = Object.values(recipes);
   return recipes;


### PR DESCRIPTION
getAllRecipes now relies on Firebase

Note: I removed the local storage setup, so recipes (if not already in local storage) will not be set in local storage. This function now solely relies on firebase and will not call to local storage. If that's a problem, I can put it back

Also note: These are failing a couple of the unit tests (notably, the update/create/delete tests). help. I'm like 76% sure that it's because those tests aren't relying on Firebase.