### PR TITLE
NO-TICKET: Split up create recipe options

### DIFF
--- a/root/css/CreateRecipe.css
+++ b/root/css/CreateRecipe.css
@@ -81,9 +81,12 @@ label > input {
 }
 
 .urlButton {
-    height: 35px;
-    border-radius: 5px;
+    height: 40px;
     font-size: 1em;
+    border-radius: 10px;
+    background-color: #F9A28B;
+    margin-left: 30px;
+    width: 130px;
   }
 
 @media only screen and (max-width: 999px) {

--- a/root/html/CreateRecipe.html
+++ b/root/html/CreateRecipe.html
@@ -19,15 +19,18 @@
       <div class="midPart">
         <h2 id="header">Create your recipe:</h2>
 
+        <h3>Import Recipe By URL</h3>
         <input
           class="urlText"
           type="text"
           id="urlText"
           placeholder="Website Link"
         />
-        <button id="urlButton" class="urlButton">Import by URL</button>
+        <button id="urlButton" class="urlButton">Import</button>
         <br />
         <br />
+        <hr>
+        <h3>Or Manually Add Your Recipe</h3>
         <input
           class="recipeName"
           type="text"


### PR DESCRIPTION
Frenemy reviewer from team 8 suggested that we make it more obvious that there are two options when creating a recipe (import or manual).

Before:
<img width="1049" alt="Screen Shot 2022-06-03 at 5 43 16 AM" src="https://user-images.githubusercontent.com/47434484/171856866-e920d03e-8c09-4bc8-b818-1a7b3394fb7d.png">

After:
<img width="1135" alt="Screen Shot 2022-06-03 at 5 43 24 AM" src="https://user-images.githubusercontent.com/47434484/171856893-42632835-1075-408e-918a-6969139a3541.png">
