### PR TITLE
NO-TICKET:Unfavorite Recipe Bugfix

### DIFF
--- a/root/scripts/recipepage.js
+++ b/root/scripts/recipepage.js
@@ -206,7 +206,7 @@ async function init() {
     const prevPage = new URL(document.referrer);
     const currentPage = new URL(window.location);
     if (prevPage.origin === currentPage.origin) {
-      window.history.back();
+      window.location = document.referrer;
     } else {
       window.location.href = new URL(window.location.origin);
     }


### PR DESCRIPTION
There was a bug where going on a favorited recipe from the account page, unfavoriting it, and clicking the back button to go back to the account page did not update the state. This PR should fix this issue.