### PR TITLE
NO-TICKET: ui issue in navbar

### DIFF
--- a/root/components/simple-custom-navbar.js
+++ b/root/components/simple-custom-navbar.js
@@ -202,7 +202,7 @@ class Navbar extends HTMLElement {
             </div>
             <a class='navbar-text-link mobile-link' id='create-mobile' href='./CreateRecipe.html'>Create Recipe</a>
             <a class='navbar-text-link mobile-link' id='account-mobile' href='./generalAccount.html'>My Account</a>
-            <a class="navbar-text-link mobile-link" id="account-mobile" href="./entry.html">Sign In</a>
+            <a class="navbar-text-link mobile-link" id="sign-in-mobile" href="./entry.html">Sign In</a>
         </div>
     `;
 
@@ -257,6 +257,10 @@ class Navbar extends HTMLElement {
       case 'account':
         navbarContainer.querySelector('#account').style.textDecoration = 'underline';
         navbarContainer.querySelector('#account-mobile').style.textDecoration = 'underline';
+        break;
+      case 'sign-in':
+        navbarContainer.querySelector('#sign-in').style.textDecoration = 'underline';
+        navbarContainer.querySelector('#sign-in-mobile').style.textDecoration = 'underline';
         break;
       default:
         break;

--- a/root/html/RecipePage.html
+++ b/root/html/RecipePage.html
@@ -16,7 +16,7 @@
 
   <body>
     <header>
-      <simple-custom-navbar />
+      <simple-custom-navbar page="recipe" />
     </header>
     <main>
       <button class="back-button" id="back-button"></button>

--- a/root/html/editRecipe.html
+++ b/root/html/editRecipe.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <header>
-      <simple-custom-navbar />
+      <simple-custom-navbar page="edit"/>
     </header>
     <main>
       <div class="midPart">

--- a/root/html/entry.html
+++ b/root/html/entry.html
@@ -18,7 +18,7 @@
 
 <body>
     <header>
-        <simple-custom-navbar />
+        <simple-custom-navbar page="sign-in" />
     </header>
     <div class="form-structor">
         <div class="signup">

--- a/root/html/generalAccount.html
+++ b/root/html/generalAccount.html
@@ -16,7 +16,7 @@
 </head>
 <body>
     <header>
-        <simple-custom-navbar />
+        <simple-custom-navbar page="account"/>
     </header>
     <main>
         <div class="accountParent">

--- a/root/html/index.html
+++ b/root/html/index.html
@@ -38,7 +38,7 @@
 
 <body>
     <header>
-        <simple-custom-navbar />
+        <simple-custom-navbar page="home"/>
     </header>
   <main>
       <!--


### PR DESCRIPTION
small problem where the new custom-navbar would only underline your active page if you were under the create recipe page (didn't underline active page otherwise)
<img width="611" alt="Screen Shot 2022-06-08 at 10 30 43 AM" src="https://user-images.githubusercontent.com/47434484/172680854-5144ceb9-579b-4944-8a13-ba2a4f714abf.png">
<img width="605" alt="Screen Shot 2022-06-08 at 10 30 38 AM" src="https://user-images.githubusercontent.com/47434484/172680839-ffa7e59b-2a98-45f3-965c-008f0a8dd03e.png">

Now will always underline the active page

